### PR TITLE
Phs/travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vagrant/*
+!.vagrant/.keep

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,49 @@
+# These may be useful:
+# http://docs.travis-ci.com/user/languages/java/
+# http://docs.travis-ci.com/user/build-configuration/#The-Build-Matrix
+
+language: java
+
+jdk:
+  - oraclejdk7
+
+# We need private-style submodule urls, but they stop travis from being able to checkout
+# the submodules.  So we disable travis' default functionality, hack the .gitmodules
+# in-place, and initialize them manually.  For more details, see
+# http://docs.travis-ci.com/user/build-configuration/#Git-Submodules
+git:
+  submodules: false
+
+before_install:
+  - "sed -i 's|git@github.com:|git://github.com/|g' .gitmodules"
+  - git submodule update --init --recursive
+
+before_script: ./provisioning/travis
+script: ./run-tests
+
+env:
+  matrix:
+    - PLATFORM=cdh4.1.5
+      COMPONENT=kiji-schema
+    - PLATFORM=cdh4.1.5
+      COMPONENT=kiji-mapreduce
+
+    - PLATFORM=cdh4.2.2
+      COMPONENT=kiji-schema
+    - PLATFORM=cdh4.2.2
+      COMPONENT=kiji-mapreduce
+
+    - PLATFORM=cdh4.3.2
+      COMPONENT=kiji-schema
+    - PLATFORM=cdh4.3.2
+      COMPONENT=kiji-mapreduce
+
+    - PLATFORM=cdh4.4.0
+      COMPONENT=kiji-schema
+    - PLATFORM=cdh4.4.0
+      COMPONENT=kiji-mapreduce
+
+    - PLATFORM=cdh4.5.0
+      COMPONENT=kiji-schema
+    - PLATFORM=cdh4.5.0
+      COMPONENT=kiji-mapreduce

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+Kiji Top Level
+==============
+
+[![Build Status
+](https://travis-ci.org/kijiproject/kiji-top-level.svg?branch=master)
+](https://travis-ci.org/kijiproject/kiji-top-level)
+
+Top level repository that contains all of Kiji sub projects.
+
+Testing
+-------
+
+This repository contains configuration for running sub project integration tests across
+a number of different, supported platforms.  This is accomplished with the Travis build
+service (click the badge above) and their [build matrix support
+](http://docs.travis-ci.com/user/build-configuration/#The-Build-Matrix).
+
+This build is broken into two steps, see `provisioning/install` and `run-tests`. The
+list of tested platforms is in `.travis.yml`.
+
+To investigate build failures, one can locally recreate the test environment with
+[Vagrant](http://www.vagrantup.com/), using the virtualbox, vmware fusion or vmware
+workstation providers.  Beyond vagrant's usual configuration options, one may select a
+default provider by echoing its name to `.vagrant/provider`. The default is virtual box.
+
+To always use vmware fusion (for example):
+```
+$ echo vmware_fusion > .vagrant/provider
+```
+
+After installation and configuration, one can create the environment and run the tests as
+follows.  Notice the choice of platform with the `PLATFORM` environment variable.
+
+```bash
+$ PLATFORM=cdh4.4.0 vagrant up
+$ vagrant ssh
+vagrant@kiji:~$ cd kiji
+vagrant@kiji:~/kiji$ ./run-tests
+vagrant@kiji:~/kiji$ exit
+$ vagrant halt  # Or `vagrant destroy -f`
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,46 @@
+begin
+  ENV['VAGRANT_DEFAULT_PROVIDER'] ||= File.read('.vagrant/provider').strip
+rescue Errno::ENOENT
+end
+
+# Choose what platform to provision with the PLATFORM environment variable.
+ENV['PLATFORM'] ||= 'cdh4.4.0'
+
+# http://docs.vagrantup.com/v2/
+Vagrant.configure('2') do |config|
+  config.vm.box = 'precise64'
+  config.vm.hostname = 'kiji'
+  config.ssh.forward_agent = true
+
+  config.vm.network 'forwarded_port', guest: 50070, host: 50070 # Namenode
+  config.vm.network 'forwarded_port', guest: 50090, host: 50090 # 2ndary Namenode
+  config.vm.network 'forwarded_port', guest: 50075, host: 50075 # Datanode
+  config.vm.network 'forwarded_port', guest: 50030, host: 50030 # Job Tracker
+  config.vm.network 'forwarded_port', guest: 50060, host: 50060 # Task Tracker
+  config.vm.network 'forwarded_port', guest: 60010, host: 60010 # HBase
+
+  config.vm.provider 'vmware_fusion' do |provider, override|
+    # provider.gui = true
+    override.vm.box_url = 'http://files.vagrantup.com/precise64_vmware.box'
+    provider.vmx['memsize'] = '3072'  # VMware refuses to start for anything larger
+    provider.vmx['numvcpus'] = '1'    # http://superuser.com/q/505711/96477
+  end
+
+  config.vm.provider 'vmware_workstation' do |provider, override|
+    # provider.gui = true
+    override.vm.box_url = 'http://files.vagrantup.com/precise64_vmware.box'
+    provider.vmx['memsize'] = '3072'
+    provider.vmx['numvcpus'] = '1'
+  end
+
+  config.vm.provider 'virtualbox' do |provider, override|
+    # provider.gui = true
+    override.vm.box_url = 'http://files.vagrantup.com/precise64.box'
+    provider.name = 'kiji'
+    provider.customize ['modifyvm', :id, '--memory', '3135'] # shrinks to 3072 inside
+    provider.customize ['modifyvm', :id, '--cpus', '2']
+  end
+
+  config.vm.provision :shell, privileged: false,
+    inline: "export PLATFORM='#{ENV['PLATFORM']}'; cd /vagrant; ./provisioning/vagrant"
+end

--- a/provisioning/install
+++ b/provisioning/install
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+# Die on error.
+set -e
+
+date
+
+# Assert some things about the running vm.
+
+# This is a ubuntu (or at least debian-flavor) image
+if [[ "$(which lsb_release)" == '' ]]
+then
+  echo "This does not appear to be an ubuntu image, refusing to continue."
+  exit 1
+fi
+
+# It is the "precise" release
+if [[ "$(lsb_release -sc)" != 'precise' ]]
+then
+  echo "This is a $(lsb_release -sc) image, not precise.  Refusing to continue."
+  exit 1
+fi
+
+# It is a 64-bit image
+if [[ "$(uname -m)" != 'x86_64' ]]
+then
+  echo "This does not appear to be 64-bit image, refusing to continue."
+  exit 1
+fi
+
+PLATFORM_DIR="./provisioning/platforms/$PLATFORM"
+
+# The platform matches an install script.
+if ! test -x "$PLATFORM_DIR/install"
+then
+  echo "Unknown platform $PLATFORM"
+  exit 1
+else
+  echo
+  echo
+  echo "Installing platform $PLATFORM"
+  echo
+  echo
+fi
+
+# Install the platform
+cd "$PLATFORM_DIR"
+. ./install

--- a/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/core-site.xml
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/core-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://localhost/</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/hadoop-env.sh
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/hadoop-env.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+# Bring in a standard environment including JAVA_HOME
+. /etc/profile

--- a/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/hadoop-metrics.properties
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/hadoop-metrics.properties
@@ -1,0 +1,75 @@
+# Configuration of the "dfs" context for null
+dfs.class=org.apache.hadoop.metrics.spi.NullContext
+
+# Configuration of the "dfs" context for file
+#dfs.class=org.apache.hadoop.metrics.file.FileContext
+#dfs.period=10
+#dfs.fileName=/tmp/dfsmetrics.log
+
+# Configuration of the "dfs" context for ganglia
+# Pick one: Ganglia 3.0 (former) or Ganglia 3.1 (latter)
+# dfs.class=org.apache.hadoop.metrics.ganglia.GangliaContext
+# dfs.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+# dfs.period=10
+# dfs.servers=localhost:8649
+
+
+# Configuration of the "mapred" context for null
+mapred.class=org.apache.hadoop.metrics.spi.NullContext
+
+# Configuration of the "mapred" context for file
+#mapred.class=org.apache.hadoop.metrics.file.FileContext
+#mapred.period=10
+#mapred.fileName=/tmp/mrmetrics.log
+
+# Configuration of the "mapred" context for ganglia
+# Pick one: Ganglia 3.0 (former) or Ganglia 3.1 (latter)
+# mapred.class=org.apache.hadoop.metrics.ganglia.GangliaContext
+# mapred.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+# mapred.period=10
+# mapred.servers=localhost:8649
+
+
+# Configuration of the "jvm" context for null
+#jvm.class=org.apache.hadoop.metrics.spi.NullContext
+
+# Configuration of the "jvm" context for file
+#jvm.class=org.apache.hadoop.metrics.file.FileContext
+#jvm.period=10
+#jvm.fileName=/tmp/jvmmetrics.log
+
+# Configuration of the "jvm" context for ganglia
+# jvm.class=org.apache.hadoop.metrics.ganglia.GangliaContext
+# jvm.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+# jvm.period=10
+# jvm.servers=localhost:8649
+
+# Configuration of the "rpc" context for null
+rpc.class=org.apache.hadoop.metrics.spi.NullContext
+
+# Configuration of the "rpc" context for file
+#rpc.class=org.apache.hadoop.metrics.file.FileContext
+#rpc.period=10
+#rpc.fileName=/tmp/rpcmetrics.log
+
+# Configuration of the "rpc" context for ganglia
+# rpc.class=org.apache.hadoop.metrics.ganglia.GangliaContext
+# rpc.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+# rpc.period=10
+# rpc.servers=localhost:8649
+
+
+# Configuration of the "ugi" context for null
+ugi.class=org.apache.hadoop.metrics.spi.NullContext
+
+# Configuration of the "ugi" context for file
+#ugi.class=org.apache.hadoop.metrics.file.FileContext
+#ugi.period=10
+#ugi.fileName=/tmp/ugimetrics.log
+
+# Configuration of the "ugi" context for ganglia
+# ugi.class=org.apache.hadoop.metrics.ganglia.GangliaContext
+# ugi.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+# ugi.period=10
+# ugi.servers=localhost:8649
+

--- a/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/hadoop-metrics2.properties
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/hadoop-metrics2.properties
@@ -1,0 +1,44 @@
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# syntax: [prefix].[source|sink].[instance].[options]
+# See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
+
+*.sink.file.class=org.apache.hadoop.metrics2.sink.FileSink
+# default sampling period
+*.period=10
+
+# The namenode-metrics.out will contain metrics from all context
+#namenode.sink.file.filename=namenode-metrics.out
+# Specifying a special sampling period for namenode:
+#namenode.sink.*.period=8
+
+#datanode.sink.file.filename=datanode-metrics.out
+
+# the following example split metrics of different
+# context to different sinks (in this case files)
+#jobtracker.sink.file_jvm.context=jvm
+#jobtracker.sink.file_jvm.filename=jobtracker-jvm-metrics.out
+#jobtracker.sink.file_mapred.context=mapred
+#jobtracker.sink.file_mapred.filename=jobtracker-mapred-metrics.out
+
+#tasktracker.sink.file.filename=tasktracker-metrics.out
+
+#maptask.sink.file.filename=maptask-metrics.out
+
+#reducetask.sink.file.filename=reducetask-metrics.out
+

--- a/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/hdfs-site.xml
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/hdfs-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>dfs.name.dir</name>
+    <value>file:///var/lib/hadoop-hdfs/cache/hdfs/dfs/name</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/log4j.properties
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/log4j.properties
@@ -1,0 +1,212 @@
+# Copyright 2011 The Apache Software Foundation
+# 
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define some default values that can be overridden by system properties
+hadoop.root.logger=INFO,console
+hadoop.log.dir=.
+hadoop.log.file=hadoop.log
+
+# Define the root logger to the system property "hadoop.root.logger".
+log4j.rootLogger=${hadoop.root.logger}, EventCounter
+
+# Logging Threshold
+log4j.threshold=ALL
+
+# Null Appender
+log4j.appender.NullAppender=org.apache.log4j.varia.NullAppender
+
+#
+# Rolling File Appender - cap space usage at 5gb.
+#
+hadoop.log.maxfilesize=256MB
+hadoop.log.maxbackupindex=20
+log4j.appender.RFA=org.apache.log4j.RollingFileAppender
+log4j.appender.RFA.File=${hadoop.log.dir}/${hadoop.log.file}
+
+log4j.appender.RFA.MaxFileSize=${hadoop.log.maxfilesize}
+log4j.appender.RFA.MaxBackupIndex=${hadoop.log.maxbackupindex}
+
+log4j.appender.RFA.layout=org.apache.log4j.PatternLayout
+
+# Pattern format: Date LogLevel LoggerName LogMessage
+log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+# Debugging Pattern format
+#log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+
+
+#
+# Daily Rolling File Appender
+#
+
+log4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.DRFA.File=${hadoop.log.dir}/${hadoop.log.file}
+
+# Rollver at midnight
+log4j.appender.DRFA.DatePattern=.yyyy-MM-dd
+
+# 30-day backup
+#log4j.appender.DRFA.MaxBackupIndex=30
+log4j.appender.DRFA.layout=org.apache.log4j.PatternLayout
+
+# Pattern format: Date LogLevel LoggerName LogMessage
+log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+# Debugging Pattern format
+#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+
+
+#
+# console
+# Add "console" to rootlogger above if you want to use this 
+#
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n
+
+#
+# TaskLog Appender
+#
+
+#Default values
+hadoop.tasklog.taskid=null
+hadoop.tasklog.iscleanup=false
+hadoop.tasklog.noKeepSplits=4
+hadoop.tasklog.totalLogFileSize=100
+hadoop.tasklog.purgeLogSplits=true
+hadoop.tasklog.logsRetainHours=12
+
+log4j.appender.TLA=org.apache.hadoop.mapred.TaskLogAppender
+log4j.appender.TLA.taskId=${hadoop.tasklog.taskid}
+log4j.appender.TLA.isCleanup=${hadoop.tasklog.iscleanup}
+log4j.appender.TLA.totalLogFileSize=${hadoop.tasklog.totalLogFileSize}
+
+log4j.appender.TLA.layout=org.apache.log4j.PatternLayout
+log4j.appender.TLA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+
+#
+#Security appender
+#
+hadoop.security.logger=INFO,NullAppender
+hadoop.security.log.maxfilesize=256MB
+hadoop.security.log.maxbackupindex=20
+log4j.category.SecurityLogger=${hadoop.security.logger}
+hadoop.security.log.file=SecurityAuth-${user.name}.audit
+log4j.appender.RFAS=org.apache.log4j.RollingFileAppender 
+log4j.appender.RFAS.File=${hadoop.log.dir}/${hadoop.security.log.file}
+log4j.appender.RFAS.layout=org.apache.log4j.PatternLayout
+log4j.appender.RFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+log4j.appender.RFAS.MaxFileSize=${hadoop.security.log.maxfilesize}
+log4j.appender.RFAS.MaxBackupIndex=${hadoop.security.log.maxbackupindex}
+
+#
+# Daily Rolling Security appender
+#
+log4j.appender.DRFAS=org.apache.log4j.DailyRollingFileAppender 
+log4j.appender.DRFAS.File=${hadoop.log.dir}/${hadoop.security.log.file}
+log4j.appender.DRFAS.layout=org.apache.log4j.PatternLayout
+log4j.appender.DRFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+log4j.appender.DRFAS.DatePattern=.yyyy-MM-dd
+
+#
+# hdfs audit logging
+#
+hdfs.audit.logger=INFO,NullAppender
+hdfs.audit.log.maxfilesize=256MB
+hdfs.audit.log.maxbackupindex=20
+log4j.logger.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=${hdfs.audit.logger}
+log4j.additivity.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=false
+log4j.appender.RFAAUDIT=org.apache.log4j.RollingFileAppender
+log4j.appender.RFAAUDIT.File=${hadoop.log.dir}/hdfs-audit.log
+log4j.appender.RFAAUDIT.layout=org.apache.log4j.PatternLayout
+log4j.appender.RFAAUDIT.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
+log4j.appender.RFAAUDIT.MaxFileSize=${hdfs.audit.log.maxfilesize}
+log4j.appender.RFAAUDIT.MaxBackupIndex=${hdfs.audit.log.maxbackupindex}
+
+#
+# mapred audit logging
+#
+mapred.audit.logger=INFO,NullAppender
+mapred.audit.log.maxfilesize=256MB
+mapred.audit.log.maxbackupindex=20
+log4j.logger.org.apache.hadoop.mapred.AuditLogger=${mapred.audit.logger}
+log4j.additivity.org.apache.hadoop.mapred.AuditLogger=false
+log4j.appender.MRAUDIT=org.apache.log4j.RollingFileAppender
+log4j.appender.MRAUDIT.File=${hadoop.log.dir}/mapred-audit.log
+log4j.appender.MRAUDIT.layout=org.apache.log4j.PatternLayout
+log4j.appender.MRAUDIT.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
+log4j.appender.MRAUDIT.MaxFileSize=${mapred.audit.log.maxfilesize}
+log4j.appender.MRAUDIT.MaxBackupIndex=${mapred.audit.log.maxbackupindex}
+
+# Custom Logging levels
+
+#log4j.logger.org.apache.hadoop.mapred.JobTracker=DEBUG
+#log4j.logger.org.apache.hadoop.mapred.TaskTracker=DEBUG
+#log4j.logger.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=DEBUG
+
+# Jets3t library
+log4j.logger.org.jets3t.service.impl.rest.httpclient.RestS3Service=ERROR
+
+#
+# Event Counter Appender
+# Sends counts of logging messages at different severity levels to Hadoop Metrics.
+#
+log4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter
+
+#
+# Job Summary Appender 
+#
+# Use following logger to send summary to separate file defined by 
+# hadoop.mapreduce.jobsummary.log.file :
+# hadoop.mapreduce.jobsummary.logger=INFO,JSA
+# 
+hadoop.mapreduce.jobsummary.logger=${hadoop.root.logger}
+hadoop.mapreduce.jobsummary.log.file=hadoop-mapreduce.jobsummary.log
+hadoop.mapreduce.jobsummary.log.maxfilesize=256MB
+hadoop.mapreduce.jobsummary.log.maxbackupindex=20
+log4j.appender.JSA=org.apache.log4j.RollingFileAppender
+log4j.appender.JSA.File=${hadoop.log.dir}/${hadoop.mapreduce.jobsummary.log.file}
+log4j.appender.JSA.MaxFileSize=${hadoop.mapreduce.jobsummary.log.maxfilesize}
+log4j.appender.JSA.MaxBackupIndex=${hadoop.mapreduce.jobsummary.log.maxbackupindex}
+log4j.appender.JSA.layout=org.apache.log4j.PatternLayout
+log4j.appender.JSA.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n
+log4j.logger.org.apache.hadoop.mapred.JobInProgress$JobSummary=${hadoop.mapreduce.jobsummary.logger}
+log4j.additivity.org.apache.hadoop.mapred.JobInProgress$JobSummary=false
+
+#
+# Yarn ResourceManager Application Summary Log 
+#
+# Set the ResourceManager summary log filename
+#yarn.server.resourcemanager.appsummary.log.file=rm-appsummary.log
+# Set the ResourceManager summary log level and appender
+#yarn.server.resourcemanager.appsummary.logger=INFO,RMSUMMARY
+
+# Appender for ResourceManager Application Summary Log
+# Requires the following properties to be set
+#    - hadoop.log.dir (Hadoop Log directory)
+#    - yarn.server.resourcemanager.appsummary.log.file (resource manager app summary log filename)
+#    - yarn.server.resourcemanager.appsummary.logger (resource manager app summary log level and appender)
+
+#log4j.logger.org.apache.hadoop.yarn.server.resourcemanager.RMAppManager$ApplicationSummary=${yarn.server.resourcemanager.appsummary.logger}
+#log4j.additivity.org.apache.hadoop.yarn.server.resourcemanager.RMAppManager$ApplicationSummary=false
+#log4j.appender.RMSUMMARY=org.apache.log4j.RollingFileAppender
+#log4j.appender.RMSUMMARY.File=${hadoop.log.dir}/${yarn.server.resourcemanager.appsummary.log.file}
+#log4j.appender.RMSUMMARY.MaxFileSize=256MB
+#log4j.appender.RMSUMMARY.MaxBackupIndex=20
+#log4j.appender.RMSUMMARY.layout=org.apache.log4j.PatternLayout
+#log4j.appender.RMSUMMARY.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n

--- a/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/mapred-site.xml
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/mapred-site.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>mapred.job.tracker</name>
+    <value>localhost:8021</value>
+  </property>
+  <property>
+    <name>mapred.tasktracker.map.tasks.maximum</name>
+    <value>1</value>
+  </property>
+  <property>
+    <name>mapred.tasktracker.reduce.tasks.maximum</name>
+    <value>1</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/slaves
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/slaves
@@ -1,0 +1,1 @@
+localhost

--- a/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/ssl-client.xml.example
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/ssl-client.xml.example
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<configuration>
+
+<property>
+  <name>ssl.client.truststore.location</name>
+  <value></value>
+  <description>Truststore to be used by clients like distcp. Must be
+  specified.
+  </description>
+</property>
+
+<property>
+  <name>ssl.client.truststore.password</name>
+  <value></value>
+  <description>Optional. Default value is "".
+  </description>
+</property>
+
+<property>
+  <name>ssl.client.truststore.type</name>
+  <value>jks</value>
+  <description>Optional. The keystore file format, default value is "jks".
+  </description>
+</property>
+
+<property>
+  <name>ssl.client.truststore.reload.interval</name>
+  <value>10000</value>
+  <description>Truststore reload check interval, in milliseconds.
+  Default value is 10000 (10 seconds).
+  </description>
+</property>
+
+<property>
+  <name>ssl.client.keystore.location</name>
+  <value></value>
+  <description>Keystore to be used by clients like distcp. Must be
+  specified.
+  </description>
+</property>
+
+<property>
+  <name>ssl.client.keystore.password</name>
+  <value></value>
+  <description>Optional. Default value is "".
+  </description>
+</property>
+
+<property>
+  <name>ssl.client.keystore.keypassword</name>
+  <value></value>
+  <description>Optional. Default value is "".
+  </description>
+</property>
+
+<property>
+  <name>ssl.client.keystore.type</name>
+  <value>jks</value>
+  <description>Optional. The keystore file format, default value is "jks".
+  </description>
+</property>
+
+</configuration>

--- a/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/ssl-server.xml.example
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hadoop/conf.kiji/ssl-server.xml.example
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<configuration>
+
+<property>
+  <name>ssl.server.truststore.location</name>
+  <value></value>
+  <description>Truststore to be used by NN and DN. Must be specified.
+  </description>
+</property>
+
+<property>
+  <name>ssl.server.truststore.password</name>
+  <value></value>
+  <description>Optional. Default value is "".
+  </description>
+</property>
+
+<property>
+  <name>ssl.server.truststore.type</name>
+  <value>jks</value>
+  <description>Optional. The keystore file format, default value is "jks".
+  </description>
+</property>
+
+<property>
+  <name>ssl.server.truststore.reload.interval</name>
+  <value>10000</value>
+  <description>Truststore reload check interval, in milliseconds.
+  Default value is 10000 (10 seconds).
+</property>
+
+<property>
+  <name>ssl.server.keystore.location</name>
+  <value></value>
+  <description>Keystore to be used by NN and DN. Must be specified.
+  </description>
+</property>
+
+<property>
+  <name>ssl.server.keystore.password</name>
+  <value></value>
+  <description>Must be specified.
+  </description>
+</property>
+
+<property>
+  <name>ssl.server.keystore.keypassword</name>
+  <value></value>
+  <description>Must be specified.
+  </description>
+</property>
+
+<property>
+  <name>ssl.server.keystore.type</name>
+  <value>jks</value>
+  <description>Optional. The keystore file format, default value is "jks".
+  </description>
+</property>
+
+</configuration>

--- a/provisioning/platforms/cdh4.1.5/files/etc/hbase/conf.kiji/hadoop-metrics.properties
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hbase/conf.kiji/hadoop-metrics.properties
@@ -1,0 +1,58 @@
+# See http://wiki.apache.org/hadoop/GangliaMetrics
+# Make sure you know whether you are using ganglia 3.0 or 3.1.
+# If 3.1, you will have to patch your hadoop instance with HADOOP-4675
+# And, yes, this file is named hadoop-metrics.properties rather than
+# hbase-metrics.properties because we're leveraging the hadoop metrics
+# package and hadoop-metrics.properties is an hardcoded-name, at least
+# for the moment.
+#
+# See also http://hadoop.apache.org/hbase/docs/current/metrics.html
+
+# Configuration of the "hbase" context for null
+hbase.class=org.apache.hadoop.metrics.spi.NullContext
+
+# Configuration of the "hbase" context for file
+# hbase.class=org.apache.hadoop.hbase.metrics.file.TimeStampingFileContext
+# hbase.period=10
+# hbase.fileName=/tmp/metrics_hbase.log
+
+# HBase-specific configuration to reset long-running stats (e.g. compactions)
+# If this variable is left out, then the default is no expiration.
+hbase.extendedperiod = 3600
+
+# Configuration of the "hbase" context for ganglia
+# Pick one: Ganglia 3.0 (former) or Ganglia 3.1 (latter)
+# hbase.class=org.apache.hadoop.metrics.ganglia.GangliaContext
+# hbase.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+# hbase.period=10
+# hbase.servers=GMETADHOST_IP:8649
+
+# Configuration of the "jvm" context for null
+jvm.class=org.apache.hadoop.metrics.spi.NullContext
+
+# Configuration of the "jvm" context for file
+# jvm.class=org.apache.hadoop.hbase.metrics.file.TimeStampingFileContext
+# jvm.period=10
+# jvm.fileName=/tmp/metrics_jvm.log
+
+# Configuration of the "jvm" context for ganglia
+# Pick one: Ganglia 3.0 (former) or Ganglia 3.1 (latter)
+# jvm.class=org.apache.hadoop.metrics.ganglia.GangliaContext
+# jvm.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+# jvm.period=10
+# jvm.servers=GMETADHOST_IP:8649
+
+# Configuration of the "rpc" context for null
+rpc.class=org.apache.hadoop.metrics.spi.NullContext
+
+# Configuration of the "rpc" context for file
+# rpc.class=org.apache.hadoop.hbase.metrics.file.TimeStampingFileContext
+# rpc.period=10
+# rpc.fileName=/tmp/metrics_rpc.log
+
+# Configuration of the "rpc" context for ganglia
+# Pick one: Ganglia 3.0 (former) or Ganglia 3.1 (latter)
+# rpc.class=org.apache.hadoop.metrics.ganglia.GangliaContext
+# rpc.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+# rpc.period=10
+# rpc.servers=GMETADHOST_IP:8649

--- a/provisioning/platforms/cdh4.1.5/files/etc/hbase/conf.kiji/hbase-env.sh
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hbase/conf.kiji/hbase-env.sh
@@ -1,0 +1,93 @@
+#
+#/**
+# * Copyright 2007 The Apache Software Foundation
+# *
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+# Set environment variables here.
+
+# Bring in a standard environment including JAVA_HOME
+. /etc/profile
+
+# Extra Java CLASSPATH elements.  Optional.
+# export HBASE_CLASSPATH=
+
+# The maximum amount of heap to use, in MB. Default is 1000.
+# export HBASE_HEAPSIZE=1000
+
+# Extra Java runtime options.
+# Below are what we set by default.  May only work with SUN JVM.
+# For more on why as well as other possible settings,
+# see http://wiki.apache.org/hadoop/PerformanceTuning
+export HBASE_OPTS="-XX:+UseConcMarkSweepGC"
+
+# Uncomment below to enable java garbage collection logging in the .out file.
+# export HBASE_OPTS="$HBASE_OPTS -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
+
+# Uncomment below if you intend to use the EXPERIMENTAL off heap cache.
+# export HBASE_OPTS="$HBASE_OPTS -XX:MaxDirectMemorySize="
+# Set hbase.offheapcache.percentage in hbase-site.xml to a nonzero value.
+
+
+# Uncomment and adjust to enable JMX exporting
+# See jmxremote.password and jmxremote.access in $JRE_HOME/lib/management to configure remote password access.
+# More details at: http://java.sun.com/javase/6/docs/technotes/guides/management/agent.html
+#
+# export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+# export HBASE_MASTER_OPTS="$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10101"
+# export HBASE_REGIONSERVER_OPTS="$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10102"
+# export HBASE_THRIFT_OPTS="$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10103"
+# export HBASE_ZOOKEEPER_OPTS="$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10104"
+
+# File naming hosts on which HRegionServers will run.  $HBASE_HOME/conf/regionservers by default.
+# export HBASE_REGIONSERVERS=${HBASE_HOME}/conf/regionservers
+
+# Uncomment and adjust to keep all the Region Server pages memory-resident using mlock(2)
+#HBASE_REGIONSERVER_MLOCK=true
+#HBASE_REGIONSERVER_UID="hbase"
+
+# Extra ssh options.  Empty by default.
+# export HBASE_SSH_OPTS="-o ConnectTimeout=1 -o SendEnv=HBASE_CONF_DIR"
+
+# Where log files are stored.  $HBASE_HOME/logs by default.
+# export HBASE_LOG_DIR=${HBASE_HOME}/logs
+
+# A string representing this instance of hbase. $USER by default.
+# export HBASE_IDENT_STRING=$USER
+
+# The scheduling priority for daemon processes.  See 'man nice'.
+# export HBASE_NICENESS=10
+
+# The directory where pid files are stored. /tmp by default.
+# export HBASE_PID_DIR=/var/hadoop/pids
+
+# Seconds to sleep between slave commands.  Unset by default.  This
+# can be useful in large clusters, where, e.g., slave rsyncs can
+# otherwise arrive faster than the master can service them.
+# export HBASE_SLAVE_SLEEP=0.1
+
+# Tell HBase whether it should manage it's own instance of Zookeeper or not.
+# export HBASE_MANAGES_ZK=true
+# The default log rolling policy is RFA, where the log file is rolled as per the size defined for the
+# RFA appender. Please refer to the log4j.properties file to see more details on this appender.
+# In case one needs to do log rolling on a date change, one should set the environment property
+# HBASE_ROOT_LOGGER to "<DESIRED_LOG LEVEL>,DRFA".
+# For example:
+# HBASE_ROOT_LOGGER=INFO,DRFA
+# The reason for changing default to RFA is to avoid the boundary case of filling out disk space as
+# DRFA doesn't put any cap on the log size. Please refer to HBase-5655 for more context.

--- a/provisioning/platforms/cdh4.1.5/files/etc/hbase/conf.kiji/hbase-policy.xml
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hbase/conf.kiji/hbase-policy.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+
+<configuration>
+  <property>
+    <name>security.client.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for HRegionInterface protocol implementations (ie. 
+    clients talking to HRegionServers)
+    The ACL is a comma-separated list of user and group names. The user and 
+    group list is separated by a blank. For e.g. "alice,bob users,wheel". 
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.admin.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for HMasterInterface protocol implementation (ie. 
+    clients talking to HMaster for admin operations).
+    The ACL is a comma-separated list of user and group names. The user and 
+    group list is separated by a blank. For e.g. "alice,bob users,wheel". 
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.masterregion.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for HMasterRegionInterface protocol implementations
+    (for HRegionServers communicating with HMaster)
+    The ACL is a comma-separated list of user and group names. The user and 
+    group list is separated by a blank. For e.g. "alice,bob users,wheel". 
+    A special value of "*" means all users are allowed.</description>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.1.5/files/etc/hbase/conf.kiji/hbase-site.xml
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hbase/conf.kiji/hbase-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Copyright 2010 The Apache Software Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+</configuration>

--- a/provisioning/platforms/cdh4.1.5/files/etc/hbase/conf.kiji/log4j.properties
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hbase/conf.kiji/log4j.properties
@@ -1,0 +1,71 @@
+# Define some default values that can be overridden by system properties
+hbase.root.logger=INFO,console
+hbase.log.dir=.
+hbase.log.file=hbase.log
+
+# Define the root logger to the system property "hbase.root.logger".
+log4j.rootLogger=${hbase.root.logger}
+
+# Logging Threshold
+log4j.threshold=ALL
+
+#
+# Daily Rolling File Appender
+#
+log4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.DRFA.File=${hbase.log.dir}/${hbase.log.file}
+
+# Rollver at midnight
+log4j.appender.DRFA.DatePattern=.yyyy-MM-dd
+
+# 30-day backup
+#log4j.appender.DRFA.MaxBackupIndex=30
+log4j.appender.DRFA.layout=org.apache.log4j.PatternLayout
+
+# Pattern format: Date LogLevel LoggerName LogMessage
+log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+
+# Debugging Pattern format
+#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+
+# Rolling File Appender properties
+hbase.log.maxfilesize=256MB
+hbase.log.maxbackupindex=20
+
+# Rolling File Appender
+log4j.appender.RFA=org.apache.log4j.RollingFileAppender
+log4j.appender.RFA.File=${hbase.log.dir}/${hbase.log.file}
+
+log4j.appender.RFA.MaxFileSize=${hbase.log.maxfilesize}
+log4j.appender.RFA.MaxBackupIndex=${hbase.log.maxbackupindex}
+
+log4j.appender.RFA.layout=org.apache.log4j.PatternLayout
+log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+
+#
+# console
+# Add "console" to rootlogger above if you want to use this 
+#
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n
+
+# Custom Logging levels
+
+log4j.logger.org.apache.zookeeper=INFO
+#log4j.logger.org.apache.hadoop.fs.FSNamesystem=DEBUG
+log4j.logger.org.apache.hadoop.hbase=DEBUG
+# Make these two classes INFO-level. Make them DEBUG to see more zk debug.
+log4j.logger.org.apache.hadoop.hbase.zookeeper.ZKUtil=INFO
+log4j.logger.org.apache.hadoop.hbase.zookeeper.ZooKeeperWatcher=INFO
+#log4j.logger.org.apache.hadoop.dfs=DEBUG
+# Set this class to log INFO only otherwise its OTT
+
+# Uncomment this line to enable tracing on _every_ RPC call (this can be a lot of output)
+#log4j.logger.org.apache.hadoop.ipc.HBaseServer.trace=DEBUG
+
+# Uncomment the below if you want to remove logging of client region caching'
+# and scan of .META. messages
+# log4j.logger.org.apache.hadoop.hbase.client.HConnectionManager$HConnectionImplementation=INFO
+# log4j.logger.org.apache.hadoop.hbase.client.MetaScanner=INFO

--- a/provisioning/platforms/cdh4.1.5/files/etc/hbase/conf.kiji/regionservers
+++ b/provisioning/platforms/cdh4.1.5/files/etc/hbase/conf.kiji/regionservers
@@ -1,0 +1,1 @@
+localhost

--- a/provisioning/platforms/cdh4.1.5/files/etc/zookeeper/conf.kiji/configuration.xsl
+++ b/provisioning/platforms/cdh4.1.5/files/etc/zookeeper/conf.kiji/configuration.xsl
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:output method="html"/>
+<xsl:template match="configuration">
+<html>
+<body>
+<table border="1">
+<tr>
+ <td>name</td>
+ <td>value</td>
+ <td>description</td>
+</tr>
+<xsl:for-each select="property">
+<tr>
+  <td><a name="{name}"><xsl:value-of select="name"/></a></td>
+  <td><xsl:value-of select="value"/></td>
+  <td><xsl:value-of select="description"/></td>
+</tr>
+</xsl:for-each>
+</table>
+</body>
+</html>
+</xsl:template>
+</xsl:stylesheet>

--- a/provisioning/platforms/cdh4.1.5/files/etc/zookeeper/conf.kiji/log4j.properties
+++ b/provisioning/platforms/cdh4.1.5/files/etc/zookeeper/conf.kiji/log4j.properties
@@ -1,0 +1,65 @@
+# Copyright 2012 The Apache Software Foundation
+# 
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define some default values that can be overridden by system properties
+zookeeper.root.logger=INFO, CONSOLE
+
+zookeeper.console.threshold=INFO
+
+zookeeper.log.dir=.
+zookeeper.log.file=zookeeper.log
+zookeeper.log.threshold=INFO
+zookeeper.log.maxfilesize=256MB
+zookeeper.log.maxbackupindex=20
+
+zookeeper.tracelog.dir=.
+zookeeper.tracelog.file=zookeeper_trace.log
+
+log4j.rootLogger=${zookeeper.root.logger}
+
+#
+# console
+# Add "console" to rootlogger above if you want to use this 
+#
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.Threshold=${zookeeper.console.threshold}
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+
+#
+# Add ROLLINGFILE to rootLogger to get log file output
+#
+log4j.appender.ROLLINGFILE=org.apache.log4j.RollingFileAppender
+log4j.appender.ROLLINGFILE.Threshold=${zookeeper.log.threshold}
+log4j.appender.ROLLINGFILE.File=${zookeeper.log.dir}/${zookeeper.log.file}
+log4j.appender.ROLLINGFILE.MaxFileSize=${zookeeper.log.maxfilesize}
+log4j.appender.ROLLINGFILE.MaxBackupIndex=${zookeeper.log.maxbackupindex}
+log4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+
+#
+# Add TRACEFILE to rootLogger to get log file output
+#    Log TRACE level and above messages to a log file
+#
+log4j.appender.TRACEFILE=org.apache.log4j.FileAppender
+log4j.appender.TRACEFILE.Threshold=TRACE
+log4j.appender.TRACEFILE.File=${zookeeper.tracelog.dir}/${zookeeper.tracelog.file}
+
+log4j.appender.TRACEFILE.layout=org.apache.log4j.PatternLayout
+### Notice we are including log4j's NDC here (%x)
+log4j.appender.TRACEFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L][%x] - %m%n

--- a/provisioning/platforms/cdh4.1.5/files/etc/zookeeper/conf.kiji/zoo.cfg
+++ b/provisioning/platforms/cdh4.1.5/files/etc/zookeeper/conf.kiji/zoo.cfg
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+maxClientCnxns=50
+# The number of milliseconds of each tick
+tickTime=2000
+# The number of ticks that the initial
+# synchronization phase can take
+initLimit=10
+# The number of ticks that can pass between
+# sending a request and getting an acknowledgement
+syncLimit=5
+# the directory where the snapshot is stored.
+dataDir=/var/lib/zookeeper
+# the port at which the clients will connect
+clientPort=2181
+server.1=localhost:2888:3888

--- a/provisioning/platforms/cdh4.1.5/files/etc/zookeeper/conf.kiji/zoo_sample.cfg
+++ b/provisioning/platforms/cdh4.1.5/files/etc/zookeeper/conf.kiji/zoo_sample.cfg
@@ -1,0 +1,25 @@
+# The number of milliseconds of each tick
+tickTime=2000
+# The number of ticks that the initial 
+# synchronization phase can take
+initLimit=10
+# The number of ticks that can pass between 
+# sending a request and getting an acknowledgement
+syncLimit=5
+# the directory where the snapshot is stored.
+# do not use /tmp for storage, /tmp here is just 
+# example sakes.
+dataDir=/tmp/zookeeper
+# the port at which the clients will connect
+clientPort=2181
+#
+# Be sure to read the maintenance section of the 
+# administrator guide before turning on autopurge.
+#
+# http://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_maintenance
+#
+# The number of snapshots to retain in dataDir
+#autopurge.snapRetainCount=3
+# Purge task interval in hours
+# Set to "0" to disable auto purge feature
+#autopurge.purgeInterval=1

--- a/provisioning/platforms/cdh4.1.5/install
+++ b/provisioning/platforms/cdh4.1.5/install
@@ -1,0 +1,70 @@
+#! /bin/bash
+
+# Add the apt repo, update
+sudo tee /etc/apt/sources.list.d/cdh.list <<EOF
+deb [arch=amd64] http://archive.cloudera.com/cdh4/ubuntu/precise/amd64/cdh precise-cdh4.1.5 contrib
+EOF
+
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 02A818DD
+sudo apt-get update
+
+# Copy in configuration files
+sudo rsync -rv files/ /
+
+# Remove 127.0.1.1 from /etc/hosts.  See http://stackoverflow.com/a/6535381/580412
+sudo sed -i "s/^127.0.1.1.*$//g" /etc/hosts
+
+# Update alternatives to point the stack at our configuration
+sudo update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.kiji 99
+sudo update-alternatives --install /etc/hbase/conf hbase-conf /etc/hbase/conf.kiji 99
+sudo update-alternatives \
+  --install /etc/zookeeper/conf zookeeper-conf /etc/zookeeper/conf.kiji 99
+
+# Install HDFS
+sudo apt-get install -y --force-yes \
+  hadoop-hdfs-datanode              \
+  hadoop-hdfs-namenode              \
+  hadoop-hdfs-secondarynamenode
+
+# Format the name node
+sudo -u hdfs hdfs namenode -format -nonInteractive
+
+# Restart HDFS and wait for it to come up
+sudo service hadoop-hdfs-datanode           restart
+sudo service hadoop-hdfs-secondarynamenode  restart
+sudo service hadoop-hdfs-namenode           restart
+
+for i in {1..6}
+do
+  hdfs dfsadmin -safemode wait && break
+  sleep 10
+done
+
+# Build all needed hdfs directory structure
+sudo -u hdfs hdfs dfs -mkdir -p /tmp
+sudo -u hdfs hdfs dfs -chmod -R 1777 /tmp
+sudo -u hdfs hdfs dfs -mkdir -p "/user/$USER"
+sudo -u hdfs hdfs dfs -chown -R "$USER" "/user/$USER"
+sudo -u hdfs hdfs dfs -mkdir -p /mapred/system
+sudo -u hdfs hdfs dfs -chown -R mapred:hadoop /mapred
+sudo -u hdfs hdfs dfs -mkdir -p /hbase
+sudo -u hdfs hdfs dfs -chown hbase /hbase
+
+# Install the rest of the stack.
+sudo apt-get install -y --force-yes \
+  hadoop-0.20-mapreduce-jobtracker  \
+  hadoop-0.20-mapreduce-tasktracker \
+  hbase-master                      \
+  hbase-regionserver                \
+  zookeeper-server
+
+# Initialize zookeeper
+sudo -u zookeeper zookeeper-server-initialize
+echo 1 | sudo tee /var/lib/zookeeper/myid
+
+# Bring up remaining services
+sudo service hadoop-0.20-mapreduce-jobtracker   restart
+sudo service hadoop-0.20-mapreduce-tasktracker  restart
+sudo service zookeeper-server                   restart
+sudo service hbase-master                       restart
+sudo service hbase-regionserver                 restart

--- a/provisioning/platforms/cdh4.2.2/files/etc/hadoop/conf.kiji/core-site.xml
+++ b/provisioning/platforms/cdh4.2.2/files/etc/hadoop/conf.kiji/core-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://localhost/</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.2.2/files/etc/hadoop/conf.kiji/hadoop-env.sh
+++ b/provisioning/platforms/cdh4.2.2/files/etc/hadoop/conf.kiji/hadoop-env.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+# Bring in a standard environment including JAVA_HOME
+. /etc/profile

--- a/provisioning/platforms/cdh4.2.2/files/etc/hadoop/conf.kiji/hdfs-site.xml
+++ b/provisioning/platforms/cdh4.2.2/files/etc/hadoop/conf.kiji/hdfs-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>dfs.name.dir</name>
+    <value>file:///var/lib/hadoop-hdfs/cache/hdfs/dfs/name</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.2.2/files/etc/hadoop/conf.kiji/mapred-site.xml
+++ b/provisioning/platforms/cdh4.2.2/files/etc/hadoop/conf.kiji/mapred-site.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>mapred.job.tracker</name>
+    <value>localhost:8021</value>
+  </property>
+  <property>
+    <name>mapred.tasktracker.map.tasks.maximum</name>
+    <value>1</value>
+  </property>
+  <property>
+    <name>mapred.tasktracker.reduce.tasks.maximum</name>
+    <value>1</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.2.2/files/etc/hadoop/conf.kiji/slaves
+++ b/provisioning/platforms/cdh4.2.2/files/etc/hadoop/conf.kiji/slaves
@@ -1,0 +1,1 @@
+localhost

--- a/provisioning/platforms/cdh4.2.2/files/etc/hbase/conf.kiji/hbase-env.sh
+++ b/provisioning/platforms/cdh4.2.2/files/etc/hbase/conf.kiji/hbase-env.sh
@@ -1,0 +1,107 @@
+#
+#/**
+# * Copyright 2007 The Apache Software Foundation
+# *
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+# Set environment variables here.
+
+# Bring in a standard environment including JAVA_HOME
+. /etc/profile
+
+# Extra Java CLASSPATH elements.  Optional.
+# export HBASE_CLASSPATH=
+
+# The maximum amount of heap to use, in MB. Default is 1000.
+# export HBASE_HEAPSIZE=1000
+
+# Extra Java runtime options.
+# Below are what we set by default.  May only work with SUN JVM.
+# For more on why as well as other possible settings,
+# see http://wiki.apache.org/hadoop/PerformanceTuning
+export HBASE_OPTS="$HBASE_OPTS -XX:+UseConcMarkSweepGC"
+
+# Uncomment below to enable java garbage collection logging in the .out file.
+# export HBASE_OPTS="$HBASE_OPTS -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps $HBASE_GC_OPTS"
+
+# Uncomment below (along with above GC logging) to put GC information in its own logfile (will set HBASE_GC_OPTS)
+# export HBASE_USE_GC_LOGFILE=true
+
+
+# Uncomment below if you intend to use the EXPERIMENTAL off heap cache.
+# export HBASE_OPTS="$HBASE_OPTS -XX:MaxDirectMemorySize="
+# Set hbase.offheapcache.percentage in hbase-site.xml to a nonzero value.
+
+
+# Uncomment and adjust to enable JMX exporting
+# See jmxremote.password and jmxremote.access in $JRE_HOME/lib/management to configure remote password access.
+# More details at: http://java.sun.com/javase/6/docs/technotes/guides/management/agent.html
+#
+# export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+# export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10101"
+# export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10102"
+# export HBASE_THRIFT_OPTS="$HBASE_THRIFT_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10103"
+# export HBASE_ZOOKEEPER_OPTS="$HBASE_ZOOKEEPER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10104"
+# export HBASE_REST_OPTS="$HBASE_REST_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10105"
+
+# File naming hosts on which HRegionServers will run.  $HBASE_HOME/conf/regionservers by default.
+# export HBASE_REGIONSERVERS=${HBASE_HOME}/conf/regionservers
+
+# Uncomment and adjust to keep all the Region Server pages mapped to be memory resident
+#HBASE_REGIONSERVER_MLOCK=true
+#HBASE_REGIONSERVER_UID="hbase"
+
+# File naming hosts on which backup HMaster will run.  $HBASE_HOME/conf/backup-masters by default.
+# export HBASE_BACKUP_MASTERS=${HBASE_HOME}/conf/backup-masters
+
+# Extra ssh options.  Empty by default.
+# export HBASE_SSH_OPTS="-o ConnectTimeout=1 -o SendEnv=HBASE_CONF_DIR"
+
+# Where log files are stored.  $HBASE_HOME/logs by default.
+# export HBASE_LOG_DIR=${HBASE_HOME}/logs
+
+# Enable remote JDWP debugging of major HBase processes. Meant for Core Developers
+# export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8070"
+# export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8071"
+# export HBASE_THRIFT_OPTS="$HBASE_THRIFT_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8072"
+# export HBASE_ZOOKEEPER_OPTS="$HBASE_ZOOKEEPER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8073"
+
+# A string representing this instance of hbase. $USER by default.
+# export HBASE_IDENT_STRING=$USER
+
+# The scheduling priority for daemon processes.  See 'man nice'.
+# export HBASE_NICENESS=10
+
+# The directory where pid files are stored. /tmp by default.
+# export HBASE_PID_DIR=/var/hadoop/pids
+
+# Seconds to sleep between slave commands.  Unset by default.  This
+# can be useful in large clusters, where, e.g., slave rsyncs can
+# otherwise arrive faster than the master can service them.
+# export HBASE_SLAVE_SLEEP=0.1
+
+# Tell HBase whether it should manage it's own instance of Zookeeper or not.
+# export HBASE_MANAGES_ZK=true
+# The default log rolling policy is RFA, where the log file is rolled as per the size defined for the
+# RFA appender. Please refer to the log4j.properties file to see more details on this appender.
+# In case one needs to do log rolling on a date change, one should set the environment property
+# HBASE_ROOT_LOGGER to "<DESIRED_LOG LEVEL>,DRFA".
+# For example:
+# HBASE_ROOT_LOGGER=INFO,DRFA
+# The reason for changing default to RFA is to avoid the boundary case of filling out disk space as
+# DRFA doesn't put any cap on the log size. Please refer to HBase-5655 for more context.

--- a/provisioning/platforms/cdh4.2.2/files/etc/hbase/conf.kiji/hbase-site.xml
+++ b/provisioning/platforms/cdh4.2.2/files/etc/hbase/conf.kiji/hbase-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Copyright 2010 The Apache Software Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+</configuration>

--- a/provisioning/platforms/cdh4.2.2/files/etc/hbase/conf.kiji/regionservers
+++ b/provisioning/platforms/cdh4.2.2/files/etc/hbase/conf.kiji/regionservers
@@ -1,0 +1,1 @@
+localhost

--- a/provisioning/platforms/cdh4.2.2/files/etc/zookeeper/conf.kiji/zoo.cfg
+++ b/provisioning/platforms/cdh4.2.2/files/etc/zookeeper/conf.kiji/zoo.cfg
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+maxClientCnxns=50
+# The number of milliseconds of each tick
+tickTime=2000
+# The number of ticks that the initial
+# synchronization phase can take
+initLimit=10
+# The number of ticks that can pass between
+# sending a request and getting an acknowledgement
+syncLimit=5
+# the directory where the snapshot is stored.
+dataDir=/var/lib/zookeeper
+# the port at which the clients will connect
+clientPort=2181
+server.1=localhost:2888:3888

--- a/provisioning/platforms/cdh4.2.2/install
+++ b/provisioning/platforms/cdh4.2.2/install
@@ -1,0 +1,70 @@
+#! /bin/bash
+
+# Add the apt repo, update
+sudo tee /etc/apt/sources.list.d/cdh.list <<EOF
+deb [arch=amd64] http://archive.cloudera.com/cdh4/ubuntu/precise/amd64/cdh precise-cdh4.2.2 contrib
+EOF
+
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 02A818DD
+sudo apt-get update
+
+# Copy in configuration files
+sudo rsync -rv files/ /
+
+# Remove 127.0.1.1 from /etc/hosts.  See http://stackoverflow.com/a/6535381/580412
+sudo sed -i "s/^127.0.1.1.*$//g" /etc/hosts
+
+# Update alternatives to point the stack at our configuration
+sudo update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.kiji 99
+sudo update-alternatives --install /etc/hbase/conf hbase-conf /etc/hbase/conf.kiji 99
+sudo update-alternatives \
+  --install /etc/zookeeper/conf zookeeper-conf /etc/zookeeper/conf.kiji 99
+
+# Install HDFS
+sudo apt-get install -y --force-yes \
+  hadoop-hdfs-datanode              \
+  hadoop-hdfs-namenode              \
+  hadoop-hdfs-secondarynamenode
+
+# Format the name node
+sudo -u hdfs hdfs namenode -format -nonInteractive
+
+# Restart HDFS and wait for it to come up
+sudo service hadoop-hdfs-datanode           restart
+sudo service hadoop-hdfs-secondarynamenode  restart
+sudo service hadoop-hdfs-namenode           restart
+
+for i in {1..6}
+do
+  hdfs dfsadmin -safemode wait && break
+  sleep 10
+done
+
+# Build all needed hdfs directory structure
+sudo -u hdfs hdfs dfs -mkdir -p /tmp
+sudo -u hdfs hdfs dfs -chmod -R 1777 /tmp
+sudo -u hdfs hdfs dfs -mkdir -p "/user/$USER"
+sudo -u hdfs hdfs dfs -chown -R "$USER" "/user/$USER"
+sudo -u hdfs hdfs dfs -mkdir -p /mapred/system
+sudo -u hdfs hdfs dfs -chown -R mapred:hadoop /mapred
+sudo -u hdfs hdfs dfs -mkdir -p /hbase
+sudo -u hdfs hdfs dfs -chown hbase /hbase
+
+# Install the rest of the stack.
+sudo apt-get install -y --force-yes \
+  hadoop-0.20-mapreduce-jobtracker  \
+  hadoop-0.20-mapreduce-tasktracker \
+  hbase-master                      \
+  hbase-regionserver                \
+  zookeeper-server
+
+# Initialize zookeeper
+sudo -u zookeeper zookeeper-server-initialize
+echo 1 | sudo tee /var/lib/zookeeper/myid
+
+# Bring up remaining services
+sudo service hadoop-0.20-mapreduce-jobtracker   restart
+sudo service hadoop-0.20-mapreduce-tasktracker  restart
+sudo service zookeeper-server                   restart
+sudo service hbase-master                       restart
+sudo service hbase-regionserver                 restart

--- a/provisioning/platforms/cdh4.3.2/files/etc/hadoop/conf.kiji/core-site.xml
+++ b/provisioning/platforms/cdh4.3.2/files/etc/hadoop/conf.kiji/core-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://localhost/</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.3.2/files/etc/hadoop/conf.kiji/hadoop-env.sh
+++ b/provisioning/platforms/cdh4.3.2/files/etc/hadoop/conf.kiji/hadoop-env.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+# Bring in a standard environment including JAVA_HOME
+. /etc/profile

--- a/provisioning/platforms/cdh4.3.2/files/etc/hadoop/conf.kiji/hdfs-site.xml
+++ b/provisioning/platforms/cdh4.3.2/files/etc/hadoop/conf.kiji/hdfs-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>dfs.name.dir</name>
+    <value>file:///var/lib/hadoop-hdfs/cache/hdfs/dfs/name</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.3.2/files/etc/hadoop/conf.kiji/mapred-site.xml
+++ b/provisioning/platforms/cdh4.3.2/files/etc/hadoop/conf.kiji/mapred-site.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>mapred.job.tracker</name>
+    <value>localhost:8021</value>
+  </property>
+  <property>
+    <name>mapred.tasktracker.map.tasks.maximum</name>
+    <value>1</value>
+  </property>
+  <property>
+    <name>mapred.tasktracker.reduce.tasks.maximum</name>
+    <value>1</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.3.2/files/etc/hadoop/conf.kiji/slaves
+++ b/provisioning/platforms/cdh4.3.2/files/etc/hadoop/conf.kiji/slaves
@@ -1,0 +1,1 @@
+localhost

--- a/provisioning/platforms/cdh4.3.2/files/etc/hbase/conf.kiji/hbase-env.sh
+++ b/provisioning/platforms/cdh4.3.2/files/etc/hbase/conf.kiji/hbase-env.sh
@@ -1,0 +1,119 @@
+#
+#/**
+# * Copyright 2007 The Apache Software Foundation
+# *
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+# Set environment variables here.
+
+# This script sets variables multiple times over the course of starting an hbase process,
+# so try to keep things idempotent unless you want to take an even deeper look
+# into the startup scripts (bin/hbase, etc.)
+
+# Bring in a standard environment including JAVA_HOME
+. /etc/profile
+
+# Extra Java CLASSPATH elements.  Optional.
+# export HBASE_CLASSPATH=
+
+# The maximum amount of heap to use, in MB. Default is 1000.
+# export HBASE_HEAPSIZE=1000
+
+# Extra Java runtime options.
+# Below are what we set by default.  May only work with SUN JVM.
+# For more on why as well as other possible settings,
+# see http://wiki.apache.org/hadoop/PerformanceTuning
+export HBASE_OPTS="-XX:+UseConcMarkSweepGC"
+
+# Uncomment below to enable java garbage collection logging for the server-side processes
+# this enables basic gc logging for the server processes to the .out file
+# export SERVER_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps $HBASE_GC_OPTS"
+
+# this enables gc logging using automatic GC log rolling. Only applies to jdk 1.6.0_34+ and 1.7.0_2+. Either use this set of options or the one above
+# export SERVER_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=1 -XX:GCLogFileSize=512M $HBASE_GC_OPTS"
+
+# Uncomment below to enable java garbage collection logging for the client processes in the .out file.
+# export CLIENT_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps $HBASE_GC_OPTS"
+
+# Uncomment below (along with above GC logging) to put GC information in its own logfile (will set HBASE_GC_OPTS).
+# This applies to both the server and client GC options above
+# export HBASE_USE_GC_LOGFILE=true
+
+
+# Uncomment below if you intend to use the EXPERIMENTAL off heap cache.
+# export HBASE_OPTS="$HBASE_OPTS -XX:MaxDirectMemorySize="
+# Set hbase.offheapcache.percentage in hbase-site.xml to a nonzero value.
+
+
+# Uncomment and adjust to enable JMX exporting
+# See jmxremote.password and jmxremote.access in $JRE_HOME/lib/management to configure remote password access.
+# More details at: http://java.sun.com/javase/6/docs/technotes/guides/management/agent.html
+#
+# export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+# export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10101"
+# export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10102"
+# export HBASE_THRIFT_OPTS="$HBASE_THRIFT_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10103"
+# export HBASE_ZOOKEEPER_OPTS="$HBASE_ZOOKEEPER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10104"
+# export HBASE_REST_OPTS="$HBASE_REST_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10105"
+
+# File naming hosts on which HRegionServers will run.  $HBASE_HOME/conf/regionservers by default.
+# export HBASE_REGIONSERVERS=${HBASE_HOME}/conf/regionservers
+
+# Uncomment and adjust to keep all the Region Server pages mapped to be memory resident
+#HBASE_REGIONSERVER_MLOCK=true
+#HBASE_REGIONSERVER_UID="hbase"
+
+# File naming hosts on which backup HMaster will run.  $HBASE_HOME/conf/backup-masters by default.
+# export HBASE_BACKUP_MASTERS=${HBASE_HOME}/conf/backup-masters
+
+# Extra ssh options.  Empty by default.
+# export HBASE_SSH_OPTS="-o ConnectTimeout=1 -o SendEnv=HBASE_CONF_DIR"
+
+# Where log files are stored.  $HBASE_HOME/logs by default.
+# export HBASE_LOG_DIR=${HBASE_HOME}/logs
+
+# Enable remote JDWP debugging of major HBase processes. Meant for Core Developers
+# export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8070"
+# export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8071"
+# export HBASE_THRIFT_OPTS="$HBASE_THRIFT_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8072"
+# export HBASE_ZOOKEEPER_OPTS="$HBASE_ZOOKEEPER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8073"
+
+# A string representing this instance of hbase. $USER by default.
+# export HBASE_IDENT_STRING=$USER
+
+# The scheduling priority for daemon processes.  See 'man nice'.
+# export HBASE_NICENESS=10
+
+# The directory where pid files are stored. /tmp by default.
+# export HBASE_PID_DIR=/var/hadoop/pids
+
+# Seconds to sleep between slave commands.  Unset by default.  This
+# can be useful in large clusters, where, e.g., slave rsyncs can
+# otherwise arrive faster than the master can service them.
+# export HBASE_SLAVE_SLEEP=0.1
+
+# Tell HBase whether it should manage it's own instance of Zookeeper or not.
+# export HBASE_MANAGES_ZK=true
+# The default log rolling policy is RFA, where the log file is rolled as per the size defined for the
+# RFA appender. Please refer to the log4j.properties file to see more details on this appender.
+# In case one needs to do log rolling on a date change, one should set the environment property
+# HBASE_ROOT_LOGGER to "<DESIRED_LOG LEVEL>,DRFA".
+# For example:
+# HBASE_ROOT_LOGGER=INFO,DRFA
+# The reason for changing default to RFA is to avoid the boundary case of filling out disk space as
+# DRFA doesn't put any cap on the log size. Please refer to HBase-5655 for more context.

--- a/provisioning/platforms/cdh4.3.2/files/etc/hbase/conf.kiji/hbase-site.xml
+++ b/provisioning/platforms/cdh4.3.2/files/etc/hbase/conf.kiji/hbase-site.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Copyright 2010 The Apache Software Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+  <property>
+    <name>hbase.cluster.distributed</name>
+    <value>true</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.3.2/files/etc/hbase/conf.kiji/regionservers
+++ b/provisioning/platforms/cdh4.3.2/files/etc/hbase/conf.kiji/regionservers
@@ -1,0 +1,1 @@
+localhost

--- a/provisioning/platforms/cdh4.3.2/files/etc/zookeeper/conf.kiji/zoo.cfg
+++ b/provisioning/platforms/cdh4.3.2/files/etc/zookeeper/conf.kiji/zoo.cfg
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+maxClientCnxns=50
+# The number of milliseconds of each tick
+tickTime=2000
+# The number of ticks that the initial
+# synchronization phase can take
+initLimit=10
+# The number of ticks that can pass between
+# sending a request and getting an acknowledgement
+syncLimit=5
+# the directory where the snapshot is stored.
+dataDir=/var/lib/zookeeper
+# the port at which the clients will connect
+clientPort=2181
+server.1=localhost:2888:3888

--- a/provisioning/platforms/cdh4.3.2/install
+++ b/provisioning/platforms/cdh4.3.2/install
@@ -1,0 +1,70 @@
+#! /bin/bash
+
+# Add the apt repo, update
+sudo tee /etc/apt/sources.list.d/cdh.list <<EOF
+deb [arch=amd64] http://archive.cloudera.com/cdh4/ubuntu/precise/amd64/cdh precise-cdh4.3.2 contrib
+EOF
+
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 02A818DD
+sudo apt-get update
+
+# Copy in configuration files
+sudo rsync -rv files/ /
+
+# Remove 127.0.1.1 from /etc/hosts.  See http://stackoverflow.com/a/6535381/580412
+sudo sed -i "s/^127.0.1.1.*$//g" /etc/hosts
+
+# Update alternatives to point the stack at our configuration
+sudo update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.kiji 99
+sudo update-alternatives --install /etc/hbase/conf hbase-conf /etc/hbase/conf.kiji 99
+sudo update-alternatives \
+  --install /etc/zookeeper/conf zookeeper-conf /etc/zookeeper/conf.kiji 99
+
+# Install HDFS
+sudo apt-get install -y --force-yes \
+  hadoop-hdfs-datanode              \
+  hadoop-hdfs-namenode              \
+  hadoop-hdfs-secondarynamenode
+
+# Format the name node
+sudo -u hdfs hdfs namenode -format -nonInteractive
+
+# Restart HDFS and wait for it to come up
+sudo service hadoop-hdfs-datanode           restart
+sudo service hadoop-hdfs-secondarynamenode  restart
+sudo service hadoop-hdfs-namenode           restart
+
+for i in {1..6}
+do
+  hdfs dfsadmin -safemode wait && break
+  sleep 10
+done
+
+# Build all needed hdfs directory structure
+sudo -u hdfs hdfs dfs -mkdir -p /tmp
+sudo -u hdfs hdfs dfs -chmod -R 1777 /tmp
+sudo -u hdfs hdfs dfs -mkdir -p "/user/$USER"
+sudo -u hdfs hdfs dfs -chown -R "$USER" "/user/$USER"
+sudo -u hdfs hdfs dfs -mkdir -p /mapred/system
+sudo -u hdfs hdfs dfs -chown -R mapred:hadoop /mapred
+sudo -u hdfs hdfs dfs -mkdir -p /hbase
+sudo -u hdfs hdfs dfs -chown hbase /hbase
+
+# Install the rest of the stack.
+sudo apt-get install -y --force-yes \
+  hadoop-0.20-mapreduce-jobtracker  \
+  hadoop-0.20-mapreduce-tasktracker \
+  hbase-master                      \
+  hbase-regionserver                \
+  zookeeper-server
+
+# Initialize zookeeper
+sudo -u zookeeper zookeeper-server-initialize
+echo 1 | sudo tee /var/lib/zookeeper/myid
+
+# Bring up remaining services
+sudo service hadoop-0.20-mapreduce-jobtracker   restart
+sudo service hadoop-0.20-mapreduce-tasktracker  restart
+sudo service zookeeper-server                   restart
+sudo service hbase-master                       restart
+sudo service hbase-regionserver                 restart

--- a/provisioning/platforms/cdh4.4.0/files/etc/hadoop/conf.kiji/core-site.xml
+++ b/provisioning/platforms/cdh4.4.0/files/etc/hadoop/conf.kiji/core-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://localhost/</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.4.0/files/etc/hadoop/conf.kiji/hadoop-env.sh
+++ b/provisioning/platforms/cdh4.4.0/files/etc/hadoop/conf.kiji/hadoop-env.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+# Bring in a standard environment including JAVA_HOME
+. /etc/profile

--- a/provisioning/platforms/cdh4.4.0/files/etc/hadoop/conf.kiji/hdfs-site.xml
+++ b/provisioning/platforms/cdh4.4.0/files/etc/hadoop/conf.kiji/hdfs-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>dfs.name.dir</name>
+    <value>file:///var/lib/hadoop-hdfs/cache/hdfs/dfs/name</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.4.0/files/etc/hadoop/conf.kiji/mapred-site.xml
+++ b/provisioning/platforms/cdh4.4.0/files/etc/hadoop/conf.kiji/mapred-site.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>mapred.job.tracker</name>
+    <value>localhost:8021</value>
+  </property>
+  <property>
+    <name>mapred.tasktracker.map.tasks.maximum</name>
+    <value>1</value>
+  </property>
+  <property>
+    <name>mapred.tasktracker.reduce.tasks.maximum</name>
+    <value>1</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.4.0/files/etc/hadoop/conf.kiji/slaves
+++ b/provisioning/platforms/cdh4.4.0/files/etc/hadoop/conf.kiji/slaves
@@ -1,0 +1,1 @@
+localhost

--- a/provisioning/platforms/cdh4.4.0/files/etc/hbase/conf.kiji/hbase-env.sh
+++ b/provisioning/platforms/cdh4.4.0/files/etc/hbase/conf.kiji/hbase-env.sh
@@ -1,0 +1,119 @@
+#
+#/**
+# * Copyright 2007 The Apache Software Foundation
+# *
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+# Set environment variables here.
+
+# This script sets variables multiple times over the course of starting an hbase process,
+# so try to keep things idempotent unless you want to take an even deeper look
+# into the startup scripts (bin/hbase, etc.)
+
+# Bring in a standard environment including JAVA_HOME
+. /etc/profile
+
+# Extra Java CLASSPATH elements.  Optional.
+# export HBASE_CLASSPATH=
+
+# The maximum amount of heap to use, in MB. Default is 1000.
+# export HBASE_HEAPSIZE=1000
+
+# Extra Java runtime options.
+# Below are what we set by default.  May only work with SUN JVM.
+# For more on why as well as other possible settings,
+# see http://wiki.apache.org/hadoop/PerformanceTuning
+export HBASE_OPTS="-XX:+UseConcMarkSweepGC"
+
+# Uncomment below to enable java garbage collection logging for the server-side processes
+# this enables basic gc logging for the server processes to the .out file
+# export SERVER_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps $HBASE_GC_OPTS"
+
+# this enables gc logging using automatic GC log rolling. Only applies to jdk 1.6.0_34+ and 1.7.0_2+. Either use this set of options or the one above
+# export SERVER_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=1 -XX:GCLogFileSize=512M $HBASE_GC_OPTS"
+
+# Uncomment below to enable java garbage collection logging for the client processes in the .out file.
+# export CLIENT_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps $HBASE_GC_OPTS"
+
+# Uncomment below (along with above GC logging) to put GC information in its own logfile (will set HBASE_GC_OPTS).
+# This applies to both the server and client GC options above
+# export HBASE_USE_GC_LOGFILE=true
+
+
+# Uncomment below if you intend to use the EXPERIMENTAL off heap cache.
+# export HBASE_OPTS="$HBASE_OPTS -XX:MaxDirectMemorySize="
+# Set hbase.offheapcache.percentage in hbase-site.xml to a nonzero value.
+
+
+# Uncomment and adjust to enable JMX exporting
+# See jmxremote.password and jmxremote.access in $JRE_HOME/lib/management to configure remote password access.
+# More details at: http://java.sun.com/javase/6/docs/technotes/guides/management/agent.html
+#
+# export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+# export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10101"
+# export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10102"
+# export HBASE_THRIFT_OPTS="$HBASE_THRIFT_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10103"
+# export HBASE_ZOOKEEPER_OPTS="$HBASE_ZOOKEEPER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10104"
+# export HBASE_REST_OPTS="$HBASE_REST_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10105"
+
+# File naming hosts on which HRegionServers will run.  $HBASE_HOME/conf/regionservers by default.
+# export HBASE_REGIONSERVERS=${HBASE_HOME}/conf/regionservers
+
+# Uncomment and adjust to keep all the Region Server pages mapped to be memory resident
+#HBASE_REGIONSERVER_MLOCK=true
+#HBASE_REGIONSERVER_UID="hbase"
+
+# File naming hosts on which backup HMaster will run.  $HBASE_HOME/conf/backup-masters by default.
+# export HBASE_BACKUP_MASTERS=${HBASE_HOME}/conf/backup-masters
+
+# Extra ssh options.  Empty by default.
+# export HBASE_SSH_OPTS="-o ConnectTimeout=1 -o SendEnv=HBASE_CONF_DIR"
+
+# Where log files are stored.  $HBASE_HOME/logs by default.
+# export HBASE_LOG_DIR=${HBASE_HOME}/logs
+
+# Enable remote JDWP debugging of major HBase processes. Meant for Core Developers
+# export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8070"
+# export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8071"
+# export HBASE_THRIFT_OPTS="$HBASE_THRIFT_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8072"
+# export HBASE_ZOOKEEPER_OPTS="$HBASE_ZOOKEEPER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8073"
+
+# A string representing this instance of hbase. $USER by default.
+# export HBASE_IDENT_STRING=$USER
+
+# The scheduling priority for daemon processes.  See 'man nice'.
+# export HBASE_NICENESS=10
+
+# The directory where pid files are stored. /tmp by default.
+# export HBASE_PID_DIR=/var/hadoop/pids
+
+# Seconds to sleep between slave commands.  Unset by default.  This
+# can be useful in large clusters, where, e.g., slave rsyncs can
+# otherwise arrive faster than the master can service them.
+# export HBASE_SLAVE_SLEEP=0.1
+
+# Tell HBase whether it should manage it's own instance of Zookeeper or not.
+# export HBASE_MANAGES_ZK=true
+# The default log rolling policy is RFA, where the log file is rolled as per the size defined for the
+# RFA appender. Please refer to the log4j.properties file to see more details on this appender.
+# In case one needs to do log rolling on a date change, one should set the environment property
+# HBASE_ROOT_LOGGER to "<DESIRED_LOG LEVEL>,DRFA".
+# For example:
+# HBASE_ROOT_LOGGER=INFO,DRFA
+# The reason for changing default to RFA is to avoid the boundary case of filling out disk space as
+# DRFA doesn't put any cap on the log size. Please refer to HBase-5655 for more context.

--- a/provisioning/platforms/cdh4.4.0/files/etc/hbase/conf.kiji/hbase-site.xml
+++ b/provisioning/platforms/cdh4.4.0/files/etc/hbase/conf.kiji/hbase-site.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Copyright 2010 The Apache Software Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+  <property>
+    <name>hbase.cluster.distributed</name>
+    <value>true</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.4.0/files/etc/hbase/conf.kiji/regionservers
+++ b/provisioning/platforms/cdh4.4.0/files/etc/hbase/conf.kiji/regionservers
@@ -1,0 +1,1 @@
+localhost

--- a/provisioning/platforms/cdh4.4.0/files/etc/zookeeper/conf.kiji/zoo.cfg
+++ b/provisioning/platforms/cdh4.4.0/files/etc/zookeeper/conf.kiji/zoo.cfg
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+maxClientCnxns=50
+# The number of milliseconds of each tick
+tickTime=2000
+# The number of ticks that the initial
+# synchronization phase can take
+initLimit=10
+# The number of ticks that can pass between
+# sending a request and getting an acknowledgement
+syncLimit=5
+# the directory where the snapshot is stored.
+dataDir=/var/lib/zookeeper
+# the port at which the clients will connect
+clientPort=2181
+server.1=localhost:2888:3888

--- a/provisioning/platforms/cdh4.4.0/install
+++ b/provisioning/platforms/cdh4.4.0/install
@@ -1,0 +1,70 @@
+#! /bin/bash
+
+# Add the apt repo, update
+sudo tee /etc/apt/sources.list.d/cdh.list <<EOF
+deb [arch=amd64] http://archive.cloudera.com/cdh4/ubuntu/precise/amd64/cdh precise-cdh4.4.0 contrib
+EOF
+
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 02A818DD
+sudo apt-get update
+
+# Copy in configuration files
+sudo rsync -rv files/ /
+
+# Remove 127.0.1.1 from /etc/hosts.  See http://stackoverflow.com/a/6535381/580412
+sudo sed -i "s/^127.0.1.1.*$//g" /etc/hosts
+
+# Update alternatives to point the stack at our configuration
+sudo update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.kiji 99
+sudo update-alternatives --install /etc/hbase/conf hbase-conf /etc/hbase/conf.kiji 99
+sudo update-alternatives \
+  --install /etc/zookeeper/conf zookeeper-conf /etc/zookeeper/conf.kiji 99
+
+# Install HDFS
+sudo apt-get install -y --force-yes \
+  hadoop-hdfs-datanode              \
+  hadoop-hdfs-namenode              \
+  hadoop-hdfs-secondarynamenode
+
+# Format the name node
+sudo -u hdfs hdfs namenode -format -nonInteractive
+
+# Restart HDFS and wait for it to come up
+sudo service hadoop-hdfs-datanode           restart
+sudo service hadoop-hdfs-secondarynamenode  restart
+sudo service hadoop-hdfs-namenode           restart
+
+for i in {1..6}
+do
+  hdfs dfsadmin -safemode wait && break
+  sleep 10
+done
+
+# Build all needed hdfs directory structure
+sudo -u hdfs hdfs dfs -mkdir -p /tmp
+sudo -u hdfs hdfs dfs -chmod -R 1777 /tmp
+sudo -u hdfs hdfs dfs -mkdir -p "/user/$USER"
+sudo -u hdfs hdfs dfs -chown -R "$USER" "/user/$USER"
+sudo -u hdfs hdfs dfs -mkdir -p /mapred/system
+sudo -u hdfs hdfs dfs -chown -R mapred:hadoop /mapred
+sudo -u hdfs hdfs dfs -mkdir -p /hbase
+sudo -u hdfs hdfs dfs -chown hbase /hbase
+
+# Install the rest of the stack.
+sudo apt-get install -y --force-yes \
+  hadoop-0.20-mapreduce-jobtracker  \
+  hadoop-0.20-mapreduce-tasktracker \
+  hbase-master                      \
+  hbase-regionserver                \
+  zookeeper-server
+
+# Initialize zookeeper
+sudo -u zookeeper zookeeper-server-initialize
+echo 1 | sudo tee /var/lib/zookeeper/myid
+
+# Bring up remaining services
+sudo service hadoop-0.20-mapreduce-jobtracker   restart
+sudo service hadoop-0.20-mapreduce-tasktracker  restart
+sudo service zookeeper-server                   restart
+sudo service hbase-master                       restart
+sudo service hbase-regionserver                 restart

--- a/provisioning/platforms/cdh4.5.0/files/etc/hadoop/conf.kiji/core-site.xml
+++ b/provisioning/platforms/cdh4.5.0/files/etc/hadoop/conf.kiji/core-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://localhost/</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.5.0/files/etc/hadoop/conf.kiji/hadoop-env.sh
+++ b/provisioning/platforms/cdh4.5.0/files/etc/hadoop/conf.kiji/hadoop-env.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+# Bring in a standard environment including JAVA_HOME
+. /etc/profile

--- a/provisioning/platforms/cdh4.5.0/files/etc/hadoop/conf.kiji/hdfs-site.xml
+++ b/provisioning/platforms/cdh4.5.0/files/etc/hadoop/conf.kiji/hdfs-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>dfs.name.dir</name>
+    <value>file:///var/lib/hadoop-hdfs/cache/hdfs/dfs/name</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.5.0/files/etc/hadoop/conf.kiji/mapred-site.xml
+++ b/provisioning/platforms/cdh4.5.0/files/etc/hadoop/conf.kiji/mapred-site.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>mapred.job.tracker</name>
+    <value>localhost:8021</value>
+  </property>
+  <property>
+    <name>mapred.tasktracker.map.tasks.maximum</name>
+    <value>1</value>
+  </property>
+  <property>
+    <name>mapred.tasktracker.reduce.tasks.maximum</name>
+    <value>1</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.5.0/files/etc/hadoop/conf.kiji/slaves
+++ b/provisioning/platforms/cdh4.5.0/files/etc/hadoop/conf.kiji/slaves
@@ -1,0 +1,1 @@
+localhost

--- a/provisioning/platforms/cdh4.5.0/files/etc/hbase/conf.kiji/hbase-env.sh
+++ b/provisioning/platforms/cdh4.5.0/files/etc/hbase/conf.kiji/hbase-env.sh
@@ -1,0 +1,119 @@
+#
+#/**
+# * Copyright 2007 The Apache Software Foundation
+# *
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+# Set environment variables here.
+
+# This script sets variables multiple times over the course of starting an hbase process,
+# so try to keep things idempotent unless you want to take an even deeper look
+# into the startup scripts (bin/hbase, etc.)
+
+# Bring in a standard environment including JAVA_HOME
+. /etc/profile
+
+# Extra Java CLASSPATH elements.  Optional.
+# export HBASE_CLASSPATH=
+
+# The maximum amount of heap to use, in MB. Default is 1000.
+# export HBASE_HEAPSIZE=1000
+
+# Extra Java runtime options.
+# Below are what we set by default.  May only work with SUN JVM.
+# For more on why as well as other possible settings,
+# see http://wiki.apache.org/hadoop/PerformanceTuning
+export HBASE_OPTS="-XX:+UseConcMarkSweepGC"
+
+# Uncomment below to enable java garbage collection logging for the server-side processes
+# this enables basic gc logging for the server processes to the .out file
+# export SERVER_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps $HBASE_GC_OPTS"
+
+# this enables gc logging using automatic GC log rolling. Only applies to jdk 1.6.0_34+ and 1.7.0_2+. Either use this set of options or the one above
+# export SERVER_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=1 -XX:GCLogFileSize=512M $HBASE_GC_OPTS"
+
+# Uncomment below to enable java garbage collection logging for the client processes in the .out file.
+# export CLIENT_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps $HBASE_GC_OPTS"
+
+# Uncomment below (along with above GC logging) to put GC information in its own logfile (will set HBASE_GC_OPTS).
+# This applies to both the server and client GC options above
+# export HBASE_USE_GC_LOGFILE=true
+
+
+# Uncomment below if you intend to use the EXPERIMENTAL off heap cache.
+# export HBASE_OPTS="$HBASE_OPTS -XX:MaxDirectMemorySize="
+# Set hbase.offheapcache.percentage in hbase-site.xml to a nonzero value.
+
+
+# Uncomment and adjust to enable JMX exporting
+# See jmxremote.password and jmxremote.access in $JRE_HOME/lib/management to configure remote password access.
+# More details at: http://java.sun.com/javase/6/docs/technotes/guides/management/agent.html
+#
+# export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+# export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10101"
+# export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10102"
+# export HBASE_THRIFT_OPTS="$HBASE_THRIFT_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10103"
+# export HBASE_ZOOKEEPER_OPTS="$HBASE_ZOOKEEPER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10104"
+# export HBASE_REST_OPTS="$HBASE_REST_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10105"
+
+# File naming hosts on which HRegionServers will run.  $HBASE_HOME/conf/regionservers by default.
+# export HBASE_REGIONSERVERS=${HBASE_HOME}/conf/regionservers
+
+# Uncomment and adjust to keep all the Region Server pages mapped to be memory resident
+#HBASE_REGIONSERVER_MLOCK=true
+#HBASE_REGIONSERVER_UID="hbase"
+
+# File naming hosts on which backup HMaster will run.  $HBASE_HOME/conf/backup-masters by default.
+# export HBASE_BACKUP_MASTERS=${HBASE_HOME}/conf/backup-masters
+
+# Extra ssh options.  Empty by default.
+# export HBASE_SSH_OPTS="-o ConnectTimeout=1 -o SendEnv=HBASE_CONF_DIR"
+
+# Where log files are stored.  $HBASE_HOME/logs by default.
+# export HBASE_LOG_DIR=${HBASE_HOME}/logs
+
+# Enable remote JDWP debugging of major HBase processes. Meant for Core Developers
+# export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8070"
+# export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8071"
+# export HBASE_THRIFT_OPTS="$HBASE_THRIFT_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8072"
+# export HBASE_ZOOKEEPER_OPTS="$HBASE_ZOOKEEPER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8073"
+
+# A string representing this instance of hbase. $USER by default.
+# export HBASE_IDENT_STRING=$USER
+
+# The scheduling priority for daemon processes.  See 'man nice'.
+# export HBASE_NICENESS=10
+
+# The directory where pid files are stored. /tmp by default.
+# export HBASE_PID_DIR=/var/hadoop/pids
+
+# Seconds to sleep between slave commands.  Unset by default.  This
+# can be useful in large clusters, where, e.g., slave rsyncs can
+# otherwise arrive faster than the master can service them.
+# export HBASE_SLAVE_SLEEP=0.1
+
+# Tell HBase whether it should manage it's own instance of Zookeeper or not.
+# export HBASE_MANAGES_ZK=true
+# The default log rolling policy is RFA, where the log file is rolled as per the size defined for the
+# RFA appender. Please refer to the log4j.properties file to see more details on this appender.
+# In case one needs to do log rolling on a date change, one should set the environment property
+# HBASE_ROOT_LOGGER to "<DESIRED_LOG LEVEL>,DRFA".
+# For example:
+# HBASE_ROOT_LOGGER=INFO,DRFA
+# The reason for changing default to RFA is to avoid the boundary case of filling out disk space as
+# DRFA doesn't put any cap on the log size. Please refer to HBase-5655 for more context.

--- a/provisioning/platforms/cdh4.5.0/files/etc/hbase/conf.kiji/hbase-site.xml
+++ b/provisioning/platforms/cdh4.5.0/files/etc/hbase/conf.kiji/hbase-site.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Copyright 2010 The Apache Software Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+  <property>
+    <name>hbase.cluster.distributed</name>
+    <value>true</value>
+  </property>
+</configuration>

--- a/provisioning/platforms/cdh4.5.0/files/etc/hbase/conf.kiji/regionservers
+++ b/provisioning/platforms/cdh4.5.0/files/etc/hbase/conf.kiji/regionservers
@@ -1,0 +1,1 @@
+localhost

--- a/provisioning/platforms/cdh4.5.0/files/etc/zookeeper/conf.kiji/zoo.cfg
+++ b/provisioning/platforms/cdh4.5.0/files/etc/zookeeper/conf.kiji/zoo.cfg
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+maxClientCnxns=50
+# The number of milliseconds of each tick
+tickTime=2000
+# The number of ticks that the initial
+# synchronization phase can take
+initLimit=10
+# The number of ticks that can pass between
+# sending a request and getting an acknowledgement
+syncLimit=5
+# the directory where the snapshot is stored.
+dataDir=/var/lib/zookeeper
+# the port at which the clients will connect
+clientPort=2181
+server.1=localhost:2888:3888

--- a/provisioning/platforms/cdh4.5.0/install
+++ b/provisioning/platforms/cdh4.5.0/install
@@ -1,0 +1,70 @@
+#! /bin/bash
+
+# Add the apt repo, update
+sudo tee /etc/apt/sources.list.d/cdh.list <<EOF
+deb [arch=amd64] http://archive.cloudera.com/cdh4/ubuntu/precise/amd64/cdh precise-cdh4.5.0 contrib
+EOF
+
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 02A818DD
+sudo apt-get update
+
+# Copy in configuration files
+sudo rsync -rv files/ /
+
+# Remove 127.0.1.1 from /etc/hosts.  See http://stackoverflow.com/a/6535381/580412
+sudo sed -i "s/^127.0.1.1.*$//g" /etc/hosts
+
+# Update alternatives to point the stack at our configuration
+sudo update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.kiji 99
+sudo update-alternatives --install /etc/hbase/conf hbase-conf /etc/hbase/conf.kiji 99
+sudo update-alternatives \
+  --install /etc/zookeeper/conf zookeeper-conf /etc/zookeeper/conf.kiji 99
+
+# Install HDFS
+sudo apt-get install -y --force-yes \
+  hadoop-hdfs-datanode              \
+  hadoop-hdfs-namenode              \
+  hadoop-hdfs-secondarynamenode
+
+# Format the name node
+sudo -u hdfs hdfs namenode -format -nonInteractive
+
+# Restart HDFS and wait for it to come up
+sudo service hadoop-hdfs-datanode           restart
+sudo service hadoop-hdfs-secondarynamenode  restart
+sudo service hadoop-hdfs-namenode           restart
+
+for i in {1..6}
+do
+  hdfs dfsadmin -safemode wait && break
+  sleep 10
+done
+
+# Build all needed hdfs directory structure
+sudo -u hdfs hdfs dfs -mkdir -p /tmp
+sudo -u hdfs hdfs dfs -chmod -R 1777 /tmp
+sudo -u hdfs hdfs dfs -mkdir -p "/user/$USER"
+sudo -u hdfs hdfs dfs -chown -R "$USER" "/user/$USER"
+sudo -u hdfs hdfs dfs -mkdir -p /mapred/system
+sudo -u hdfs hdfs dfs -chown -R mapred:hadoop /mapred
+sudo -u hdfs hdfs dfs -mkdir -p /hbase
+sudo -u hdfs hdfs dfs -chown hbase /hbase
+
+# Install the rest of the stack.
+sudo apt-get install -y --force-yes \
+  hadoop-0.20-mapreduce-jobtracker  \
+  hadoop-0.20-mapreduce-tasktracker \
+  hbase-master                      \
+  hbase-regionserver                \
+  zookeeper-server
+
+# Initialize zookeeper
+sudo -u zookeeper zookeeper-server-initialize
+echo 1 | sudo tee /var/lib/zookeeper/myid
+
+# Bring up remaining services
+sudo service hadoop-0.20-mapreduce-jobtracker   restart
+sudo service hadoop-0.20-mapreduce-tasktracker  restart
+sudo service zookeeper-server                   restart
+sudo service hbase-master                       restart
+sudo service hbase-regionserver                 restart

--- a/provisioning/travis
+++ b/provisioning/travis
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+# Die on error.
+set -e
+
+date
+
+# Get some hardware details
+set -x
+hostname
+uname -a
+free -m
+df -h
+set +x
+
+# Drop into the common provisioning script
+. ./provisioning/install

--- a/provisioning/vagrant
+++ b/provisioning/vagrant
@@ -1,0 +1,58 @@
+#! /bin/bash
+
+# Die on error.
+set -e
+
+date
+
+# Grab oracle jdk 7
+sudo tee /etc/apt/sources.list.d/oracle-jdk-7.list <<EOF
+deb http://ppa.launchpad.net/webupd8team/java/ubuntu precise main
+deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu precise main
+EOF
+
+# Accept the license
+echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
+
+sudo apt-get update
+
+# Install it, maven and some other small nicities
+sudo apt-get install -y --force-yes \
+  curl                    \
+  dstat                   \
+  iftop                   \
+  iotop                   \
+  lsof                    \
+  man-db                  \
+  maven                   \
+  mlocate                 \
+  nano                    \
+  oracle-java7-installer  \
+  rsync                   \
+  sysstat                 \
+  unzip                   \
+  vim                     \
+  zip
+
+# Select the active java installation
+sudo update-java-alternatives -s java-7-oracle
+
+# Set a system-wide JAVA_HOME
+sudo tee /etc/profile.d/java.sh <<'EOF'
+JAVA_HOME=/usr/lib/jvm/java-7-oracle
+EOF
+
+# Tweak the ruby prompts for hbase shell
+cat > /home/vagrant/.irbrc <<'EOF'
+require 'pp'
+require 'English'
+require 'irb/completion'
+IRB.conf[:AUTO_INDENT] = true
+IRB.conf[:PROMPT_MODE] = :SIMPLE
+EOF
+
+# Make a softlink in the user's home to the location of the shared checkout.
+ln -s /vagrant /home/vagrant/kiji
+
+# Drop into the common provisioning script
+. ./provisioning/install

--- a/run-tests
+++ b/run-tests
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+# Die on error.
+set -e
+
+date
+
+# Descend into chosen sub projects and run their integration test suites.
+# One can pick a particular sub project with the COMPONENT environment variable.
+
+if [[ "${COMPONENT:-kiji-schema}" == 'kiji-schema' ]]
+then
+  pushd kiji-schema
+
+  # Prevent a problem with cleanup.log and the enforcer plugin
+  # See https://groups.google.com/a/kiji.org/d/topic/dev/_iNQBJa0lCc/discussion
+  mkdir -p kiji-schema/target
+  echo -n > kiji-schema/target/cleanup.log
+
+  mvn verify \
+    -Dkiji.test.cluster.uri=kiji://localhost:2181/                \
+    -Dorg.kiji.schema.test.cleanup.after.test=false               \
+    -Dmaven.javadoc.skip                                          \
+    -Dcheckstyle.skip=true                                        \
+    -DskipUnitTests
+  popd
+fi
+
+if [[ "${COMPONENT:-kiji-mapreduce}" == 'kiji-mapreduce' ]]
+then
+  pushd kiji-mapreduce
+  mvn verify \
+    -Dkiji.test.cluster.uri=kiji://localhost:2181/                \
+    -Dorg.kiji.schema.test.cleanup.after.test=false               \
+    -Dmaven.javadoc.skip                                          \
+    -Dcheckstyle.skip=true                                        \
+    -DskipUnitTests
+  popd
+fi


### PR DESCRIPTION
Add travis and vagrant, use a build matrix to select platform.

Per the travis user documentation at
- http://docs.travis-ci.com/user/languages/java/
- http://docs.travis-ci.com/user/build-configuration/#The-Build-Matrix

..we enable several parallel builds using the latest cloudera CDH versions supported by the latest bento (ebi 2.0.1).  The choice of sub project test suite is also brought into the build matrix to keep build wall time down (by increasing build parallelism.)

All builds are run with Oracle JDK 7 (travis no longer offers JDK 6 since its End of Life.)

Vagrant enables us to locally reproduce an environment very similar to travis'.  To select a default provider, echo its name to `.vagrant/provider`. The default is virtual box.

To always use vmware fusion (for example):

```
$ echo vmware_fusion > .vagrant/provider
```

After installation and configuration, one can create the environment and run the tests as follows.  Notice the choice of platform with the `PLATFORM` environment variable.

``` bash
$ PLATFORM=cdh4.4.0 vagrant up
$ vagrant ssh
vagrant@kiji:~$ cd kiji
vagrant@kiji:~/kiji$ ./run-tests
vagrant@kiji:~/kiji$ exit
$ vagrant halt  # Or `vagrant destroy -f`
```

The support files for the different platforms themselves are found under `provisioning/platforms`, each in a titular directory.  Each such directory contains some common elements:
- a `install` script, which provisions that platform
- a `files` directory containing a file system overlay of configuration files and other bits.  Browsing these is the easiest way to examine the chosen configuration for each platform.

Generally only the minimal amount of configuration is performed for each platform.
